### PR TITLE
Fix table name handling related bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Edit *base.php* and fill/replace the following :
 
 You will need a MySQL database for Search Console Archive AND a user granted for CREATE, SELECT, INSERT, UPDATE, DELETE
 
-- Open *docs/sql/website.sql*, replace the {%website%} token with your website name 
+- Open *docs/sql/website.sql*, replace the {%website_table%} token with your website's table name
 (The ['table'] key used in the website array in the configuration file)
 - Run the SQL code to in your MySQL Database to create base tables for every website you want to add
 - Open *docs/sql/filters.sql*, replace the {%website%} token with your website name 

--- a/cron.php
+++ b/cron.php
@@ -99,11 +99,11 @@ foreach ($configuration['websites'] as $website) {
                 # Using Results
                 foreach ($data->getRows() as $data) {
                     # SQL Statistics Query
-                    $sql[] = 'REPLACE INTO ' . str_replace(array(
+                    $sql[] = 'REPLACE INTO `' . str_replace(array(
                         '{%device%}',
                         '{%website%}'), array(
                         $device,
-                        $website['table']), $configuration['database']['table']['pages']) . ' (`page`,`impressions`,`clicks`,`position`,`date`)
+                        $website['table']), $configuration['database']['table']['pages']) . '` (`page`,`impressions`,`clicks`,`position`,`date`)
                           VALUES (\'' . $database->_handle()->real_escape_string(str_replace($website['url'], '', $data->keys[0])) . '\',' . (integer)$data->impressions . ',' . (integer)$data->clicks . ',' . (float)round($data->position, 1) . ',\'' . $data->keys[1] . '\');';
                 }
 
@@ -120,11 +120,11 @@ foreach ($configuration['websites'] as $website) {
                 'to' => $time))) != false) {
                 foreach ($data->getRows() as $data) {
                     # SQL Statistics Query
-                    $sql[] = 'REPLACE INTO ' . str_replace(array(
+                    $sql[] = 'REPLACE INTO `' . str_replace(array(
                         '{%device%}',
                         '{%website%}'), array(
                         $device,
-                        $website['table']), $configuration['database']['table']['queries']) . ' (`query`,`impressions`,`clicks`,`position`,`date`)
+                        $website['table']), $configuration['database']['table']['queries']) . '` (`query`,`impressions`,`clicks`,`position`,`date`)
                           VALUES (\'' . $database->_handle()->real_escape_string($data->keys[0]) . '\',' . (integer)$data->impressions . ',' . (integer)$data->clicks . ', \'' . (float)round($data->position, 1) . '\',\'' . $data->keys[1] . '\')';
                 }
 

--- a/docs/sql/website.sql
+++ b/docs/sql/website.sql
@@ -1,5 +1,5 @@
 #
-# Don't forget to replace {%website%} token with your website configuration name (id in the sample)
+# Don't forget to replace {%website_table%} token with your table name of the website configuration (id in the sample)
 #
 #'websites' => array(
 #        'id' => array(
@@ -9,7 +9,7 @@
 # Create these six tables for every website you want to add
 #
 
-CREATE TABLE `pages_desktop_{%website%}` (
+CREATE TABLE `pages_desktop_{%website_table%}` (
   `page` varchar(250) NOT NULL,
   `impressions` int(11) NOT NULL,
   `clicks` int(11) NOT NULL,
@@ -19,7 +19,7 @@ CREATE TABLE `pages_desktop_{%website%}` (
   KEY `DATE` (`date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `pages_mobile_{%website%}` (
+CREATE TABLE `pages_mobile_{%website_table%}` (
   `page` varchar(250) NOT NULL,
   `impressions` int(11) NOT NULL,
   `clicks` int(11) NOT NULL,
@@ -29,7 +29,7 @@ CREATE TABLE `pages_mobile_{%website%}` (
   KEY `DATE` (`date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `pages_tablet_{%website%}` (
+CREATE TABLE `pages_tablet_{%website_table%}` (
   `page` varchar(250) NOT NULL,
   `impressions` int(11) NOT NULL,
   `clicks` int(11) NOT NULL,
@@ -39,7 +39,7 @@ CREATE TABLE `pages_tablet_{%website%}` (
   KEY `DATE` (`date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `queries_desktop_{%website%}` (
+CREATE TABLE `queries_desktop_{%website_table%}` (
   `query` varchar(250) NOT NULL,
   `impressions` int(11) NOT NULL,
   `clicks` int(11) NOT NULL,
@@ -49,7 +49,7 @@ CREATE TABLE `queries_desktop_{%website%}` (
   KEY `DATE` (`date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `queries_mobile_{%website%}` (
+CREATE TABLE `queries_mobile_{%website_table%}` (
   `query` varchar(250) NOT NULL,
   `impressions` int(11) NOT NULL,
   `clicks` int(11) NOT NULL,
@@ -59,7 +59,7 @@ CREATE TABLE `queries_mobile_{%website%}` (
   KEY `DATE` (`date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `queries_tablet_{%website%}` (
+CREATE TABLE `queries_tablet_{%website_table%}` (
   `query` varchar(250) NOT NULL,
   `impressions` int(11) NOT NULL,
   `clicks` int(11) NOT NULL,

--- a/models/database.php
+++ b/models/database.php
@@ -73,11 +73,11 @@ class Database
     public function average($date, $website, $device)
     {
         $query = 'SELECT AVG(position) AS average
-                  FROM ' . str_replace(array(
+                  FROM `' . str_replace(array(
             '{%device%}',
             '{%website%}'), array(
             self::_handle()->real_escape_string($device),
-            self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
+            self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '`
                   WHERE date = \'' . self::_handle()->real_escape_string($date) . '\';';
 
         # Executing Query
@@ -95,9 +95,9 @@ class Database
     public function ratio($date, $website, $device)
     {
         $query = 'SELECT (ROUND((SUM(clicks)) / (SUM(impressions)) * 100)) AS ctr
-                  FROM ' . str_replace(array('{%device%}', '{%website%}'),
+                  FROM `' . str_replace(array('{%device%}', '{%website%}'),
                               array(self::_handle()->real_escape_string($device),
-                                  self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
+                                  self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '`
                   WHERE query NOT LIKE \'ouestfrance\' AND query NOT LIKE \'ouest france\'
                         AND date = \'' . self::_handle()->real_escape_string($date) . '\';';
 
@@ -119,27 +119,27 @@ class Database
         switch ($query) {
             case 'query' :
                 $query = 'SELECT MAX(date) AS date
-                          FROM ' . str_replace(array(
+                          FROM `' . str_replace(array(
                     '{%device%}',
                     '{%website%}'), array(
                     self::_handle()->real_escape_string($device),
-                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']);
+                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '`';
                 break;
             case 'page' :
                 $query = 'SELECT MAX(date) AS date
-                          FROM ' . str_replace(array(
+                          FROM `' . str_replace(array(
                     '{%device%}',
                     '{%website%}'), array(
                     self::_handle()->real_escape_string($device),
-                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']);
+                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '`';
                 break;
             case 'keywords' :
                 $query = 'SELECT MAX(date) AS date
-                          FROM ' . str_replace(array(
+                          FROM `' . str_replace(array(
                     '{%device%}',
                     '{%website%}'), array(
                     self::_handle()->real_escape_string($device),
-                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']);
+                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '`';
                 break;
         }
 
@@ -165,19 +165,19 @@ class Database
         switch ($query) {
             case 'query' :
                 $query = 'SELECT COUNT(DISTINCT query) AS count
-                          FROM ' . str_replace(array(
+                          FROM `' . str_replace(array(
                     '{%device%}',
                     '{%website%}'), array(
                     self::_handle()->real_escape_string($device),
-                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']);
+                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '`';
                 break;
             case 'page' :
                 $query = 'SELECT COUNT(DISTINCT page) AS count
-                          FROM ' . str_replace(array(
+                          FROM `' . str_replace(array(
                     '{%device%}',
                     '{%website%}'), array(
                     self::_handle()->real_escape_string($device),
-                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']);
+                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '`';
                 break;
         }
 
@@ -311,11 +311,11 @@ class Database
                                      SUM(clicks) AS clicks,
                                      ROUND(AVG(position), 1) AS position,
                              ' . $date . '
-                              FROM ' . str_replace(array(
+                              FROM `' . str_replace(array(
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '`
                               WHERE ' . ((empty($interval) === false) ? (is_array($interval) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') : '') . ((empty($interval) === false) && (empty($removals) === false) ? ' AND ' : '') . ((empty($removals) === false) ? ' (' . implode(' AND ', $removals) . ') ' : '') . (((empty($interval) === false) || (empty($removals) === false)) && (empty($preservals) === false) ? ' AND ' : '') . ((empty($preservals) === false) ? ' (' . implode(' OR ', $preservals) . ')' : '') . '
                               GROUP BY ' . $date . '
                               ORDER BY ' . $date . ' DESC';
@@ -325,11 +325,11 @@ class Database
                                      SUM(clicks) AS clicks,
                                      ROUND(AVG(position), 1) AS position,
                              ' . $date . '
-                              FROM ' . str_replace(array(
+                              FROM `' . str_replace(array(
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '`
                               WHERE ' . ((empty($interval) === false) ? (is_array($interval) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') : '') . ((empty($interval) === false) && (empty($removals) === false) ? ' AND ' : '') . ((empty($removals) === false) ? ' (' . implode(' AND ', $removals) . ') ' : '') . (((empty($interval) === false) || (empty($removals) === false)) && (empty($preservals) === false) ? ' AND ' : '') . ((empty($preservals) === false) ? ' (' . implode(' OR ', $preservals) . ')' : '') . '
                               GROUP BY ' . $date . '
                               ORDER BY ' . $date . ' DESC';
@@ -350,11 +350,11 @@ class Database
                                      SUM(clicks) AS clicks,
                                      ROUND(AVG(position), 1) AS position,
                              ' . $date . '
-                              FROM ' . str_replace(array(
+                              FROM `' . str_replace(array(
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '`
                               WHERE query = \'' . self::_handle()->real_escape_string(strtolower($search)) . '\'' . ((empty($interval) === false) ? (is_array($interval) ? ' AND date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' AND date = \'' . $interval . '\'') : '') . '
                               GROUP BY ' . $date . '
                               ORDER BY ' . $date . ' DESC';
@@ -364,11 +364,11 @@ class Database
                                      SUM(clicks) AS clicks,
                                      ROUND(AVG(position), 1) AS position,
                              ' . $date . '
-                              FROM ' . str_replace(array(
+                              FROM `' . str_replace(array(
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '`
                               WHERE page = \'' . self::_handle()->real_escape_string(strtolower($search)) . '\'' . ((empty($interval) === false) ? (is_array($interval) ? ' AND date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' AND date = \'' . $interval . '\'') : '') . '
                               GROUP BY ' . $date . '
                               ORDER BY ' . $date . ' DESC';
@@ -482,11 +482,11 @@ class Database
                                      SUM(impressions) AS impressions,
                                      SUM(clicks) AS clicks,
                                      ROUND(AVG(position), 1) AS position
-                               FROM ' . str_replace(array(
+                               FROM `' . str_replace(array(
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '`
                                WHERE ' . ((is_array($interval)) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') . ((empty($removals) === false) ? ' AND (' . implode(' AND ', $removals) . ')' : '') . ((empty($preservals) === false) ? ' AND (' . implode(' OR ', $preservals) . ')' : '') . '
                                GROUP BY query
                                ORDER BY clicks DESC';
@@ -495,11 +495,11 @@ class Database
                                      impressions,
                                      clicks,
                                      position
-                               FROM ' . str_replace(array(
+                               FROM `' . str_replace(array(
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '`
                                WHERE ' . ((is_array($interval)) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') . ((empty($removals) === false) ? ' AND (' . implode(' AND ', $removals) . ')' : '') . ((empty($preservals) === false) ? ' AND (' . implode(' OR ', $preservals) . ')' : '') . '
                                ORDER BY clicks DESC';
                 }
@@ -510,11 +510,11 @@ class Database
                                      SUM(impressions) AS impressions,
                                      SUM(clicks) AS clicks,
                                      ROUND(AVG(position), 1) AS position
-                               FROM ' . str_replace(array(
+                               FROM `' . str_replace(array(
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '`
                                WHERE ' . ((is_array($interval)) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') . ((empty($removals) === false) ? ' AND (' . implode(' AND ', $removals) . ')' : '') . ((empty($preservals) === false) ? ' AND (' . implode(' OR ', $preservals) . ')' : '') . '
                                GROUP BY page
                                ORDER BY clicks DESC';
@@ -523,11 +523,11 @@ class Database
                                      impressions,
                                      clicks,
                                      position
-                               FROM ' . str_replace(array(
+                               FROM `' . str_replace(array(
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '`
                                WHERE ' . ((is_array($interval)) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') . ((empty($removals) === false) ? ' AND (' . implode(' AND ', $removals) . ')' : '') . ((empty($preservals) === false) ? ' AND (' . implode(' OR ', $preservals) . ')' : '') . '
                                ORDER BY clicks DESC';
                 }
@@ -549,7 +549,7 @@ class Database
         switch ($action) {
             case 'delete' :
                 $query = 'DELETE
-                          FROM filters
+                          FROM `filters`
                           WHERE website = \'' . self::_handle()->real_escape_string(strtolower($website)) . '\'
                                 AND query = \'' . self::_handle()->real_escape_string(strtolower($query)) . '\'
                                 AND name = \'' . self::_handle()->real_escape_string(strtoupper($data['name'])) . '\'
@@ -563,7 +563,7 @@ class Database
                 return true;
                 break;
             case 'add' :
-                $query = 'INSERT INTO filters
+                $query = 'INSERT INTO `filters`
                           (`name`,`query`,`value`,`website`)
                           VALUES (\'' . self::_handle()->real_escape_string(strtoupper($data['name'])) . '\',
                                   \'' . self::_handle()->real_escape_string(strtolower($query)) . '\',
@@ -579,7 +579,7 @@ class Database
                 break;
             default :
                 $query = 'SELECT *
-                          FROM filters
+                          FROM `filters`
                           WHERE website = \'' . self::_handle()->real_escape_string(strtolower($website)) . '\'
                                 AND query = \'' . self::_handle()->real_escape_string(strtolower($query)) . '\'';
 

--- a/models/database.php
+++ b/models/database.php
@@ -77,7 +77,7 @@ class Database
             '{%device%}',
             '{%website%}'), array(
             self::_handle()->real_escape_string($device),
-            self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['queries']) . '
+            self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
                   WHERE date = \'' . self::_handle()->real_escape_string($date) . '\';';
 
         # Executing Query
@@ -97,7 +97,7 @@ class Database
         $query = 'SELECT (ROUND((SUM(clicks)) / (SUM(impressions)) * 100)) AS ctr
                   FROM ' . str_replace(array('{%device%}', '{%website%}'),
                               array(self::_handle()->real_escape_string($device),
-                                  self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['queries']) . '
+                                  self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
                   WHERE query NOT LIKE \'ouestfrance\' AND query NOT LIKE \'ouest france\'
                         AND date = \'' . self::_handle()->real_escape_string($date) . '\';';
 
@@ -123,7 +123,7 @@ class Database
                     '{%device%}',
                     '{%website%}'), array(
                     self::_handle()->real_escape_string($device),
-                    self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['queries']);
+                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']);
                 break;
             case 'page' :
                 $query = 'SELECT MAX(date) AS date
@@ -131,7 +131,7 @@ class Database
                     '{%device%}',
                     '{%website%}'), array(
                     self::_handle()->real_escape_string($device),
-                    self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['pages']);
+                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']);
                 break;
             case 'keywords' :
                 $query = 'SELECT MAX(date) AS date
@@ -139,7 +139,7 @@ class Database
                     '{%device%}',
                     '{%website%}'), array(
                     self::_handle()->real_escape_string($device),
-                    self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['pages']);
+                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']);
                 break;
         }
 
@@ -169,7 +169,7 @@ class Database
                     '{%device%}',
                     '{%website%}'), array(
                     self::_handle()->real_escape_string($device),
-                    self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['queries']);
+                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']);
                 break;
             case 'page' :
                 $query = 'SELECT COUNT(DISTINCT page) AS count
@@ -177,7 +177,7 @@ class Database
                     '{%device%}',
                     '{%website%}'), array(
                     self::_handle()->real_escape_string($device),
-                    self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['pages']);
+                    self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']);
                 break;
         }
 
@@ -315,7 +315,7 @@ class Database
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['queries']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
                               WHERE ' . ((empty($interval) === false) ? (is_array($interval) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') : '') . ((empty($interval) === false) && (empty($removals) === false) ? ' AND ' : '') . ((empty($removals) === false) ? ' (' . implode(' AND ', $removals) . ') ' : '') . (((empty($interval) === false) || (empty($removals) === false)) && (empty($preservals) === false) ? ' AND ' : '') . ((empty($preservals) === false) ? ' (' . implode(' OR ', $preservals) . ')' : '') . '
                               GROUP BY ' . $date . '
                               ORDER BY ' . $date . ' DESC';
@@ -329,7 +329,7 @@ class Database
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['pages']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '
                               WHERE ' . ((empty($interval) === false) ? (is_array($interval) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') : '') . ((empty($interval) === false) && (empty($removals) === false) ? ' AND ' : '') . ((empty($removals) === false) ? ' (' . implode(' AND ', $removals) . ') ' : '') . (((empty($interval) === false) || (empty($removals) === false)) && (empty($preservals) === false) ? ' AND ' : '') . ((empty($preservals) === false) ? ' (' . implode(' OR ', $preservals) . ')' : '') . '
                               GROUP BY ' . $date . '
                               ORDER BY ' . $date . ' DESC';
@@ -354,7 +354,7 @@ class Database
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['queries']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
                               WHERE query = \'' . self::_handle()->real_escape_string(strtolower($search)) . '\'' . ((empty($interval) === false) ? (is_array($interval) ? ' AND date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' AND date = \'' . $interval . '\'') : '') . '
                               GROUP BY ' . $date . '
                               ORDER BY ' . $date . ' DESC';
@@ -368,7 +368,7 @@ class Database
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['pages']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '
                               WHERE page = \'' . self::_handle()->real_escape_string(strtolower($search)) . '\'' . ((empty($interval) === false) ? (is_array($interval) ? ' AND date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' AND date = \'' . $interval . '\'') : '') . '
                               GROUP BY ' . $date . '
                               ORDER BY ' . $date . ' DESC';
@@ -486,7 +486,7 @@ class Database
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['queries']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
                                WHERE ' . ((is_array($interval)) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') . ((empty($removals) === false) ? ' AND (' . implode(' AND ', $removals) . ')' : '') . ((empty($preservals) === false) ? ' AND (' . implode(' OR ', $preservals) . ')' : '') . '
                                GROUP BY query
                                ORDER BY clicks DESC';
@@ -499,7 +499,7 @@ class Database
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['queries']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['queries']) . '
                                WHERE ' . ((is_array($interval)) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') . ((empty($removals) === false) ? ' AND (' . implode(' AND ', $removals) . ')' : '') . ((empty($preservals) === false) ? ' AND (' . implode(' OR ', $preservals) . ')' : '') . '
                                ORDER BY clicks DESC';
                 }
@@ -514,7 +514,7 @@ class Database
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['pages']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '
                                WHERE ' . ((is_array($interval)) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') . ((empty($removals) === false) ? ' AND (' . implode(' AND ', $removals) . ')' : '') . ((empty($preservals) === false) ? ' AND (' . implode(' OR ', $preservals) . ')' : '') . '
                                GROUP BY page
                                ORDER BY clicks DESC';
@@ -527,7 +527,7 @@ class Database
                         '{%device%}',
                         '{%website%}'), array(
                         self::_handle()->real_escape_string($device),
-                        self::_handle()->real_escape_string($website)), self::$_configuration['database']['table']['pages']) . '
+                        self::_handle()->real_escape_string(self::website_table_name($website))), self::$_configuration['database']['table']['pages']) . '
                                WHERE ' . ((is_array($interval)) ? ' date >= \'' . $interval['from'] . '\' AND date <= \'' . $interval['to'] . '\' ' : ' date = \'' . $interval . '\'') . ((empty($removals) === false) ? ' AND (' . implode(' AND ', $removals) . ')' : '') . ((empty($preservals) === false) ? ' AND (' . implode(' OR ', $preservals) . ')' : '') . '
                                ORDER BY clicks DESC';
                 }
@@ -592,6 +592,11 @@ class Database
                 break;
         }
         return $data;
+    }
+
+    public function website_table_name($website)
+    {
+        return self::$_configuration['websites'][$website]['table'];
     }
 
     private function _trace($message)


### PR DESCRIPTION
Hi. Thanks for the superb software, it is very useful and it helps me a lot 😄 

However, I faced several issues on first time setup around database table name handling. This PR fixes the following issues.

1. Configured table names are not used by `Database` class.

    The configuration file has table name settings (`table` key in `websites` array), but this field is not used properly.

    The `cron.php` uses correct table names configured in `base.php`, but `Database` class does not use them.

2. Table names contains *dot*(s) cause incorrect query error

    Because when constructing SQL queries, table names are not wrapped with backquotes. 

3. Instruction of the modifying `docs/sql/website.sql` file can cause misreading

   The meaning of `{%website%}` placeholder is not the same as `docs/sql/filters.sql`. This placeholder should be replaced with **table name**, not **site name**.